### PR TITLE
Show only `key` in path segments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,10 +52,10 @@ function stringify(value: mixed): string {
 function getContextPath(context: Context): string {
   return context.map(({ key, name }, index) => {
     if (index === context.length - 1) {
-      return key ? `${key}: ${name}` : name;
+      return key ? `${key}: ${name}` : name
     }
-    return key || name;
-  }).join('/');
+    return key || name
+  }).join('/')
 }
 
 function getDefaultDescription(value: mixed, context: Context): string {

--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,12 @@ function stringify(value: mixed): string {
 }
 
 function getContextPath(context: Context): string {
-  return context.map(({ key, name }) => `${key}: ${name}`).join('/')
+  return context.map(({ key, name }, index) => {
+    if (index === context.length - 1) {
+      return key ? `${key}: ${name}` : name;
+    }
+    return key || name;
+  }).join('/');
 }
 
 function getDefaultDescription(value: mixed, context: Context): string {

--- a/test/$exact.js
+++ b/test/$exact.js
@@ -33,20 +33,20 @@ describe('$exact', () => {
   it('should fail validating an invalid value', () => {
     const T = t.$exact({ a: t.string })
     assertValidationFailure(t.validate(1, T), [
-      'Invalid value 1 supplied to : $Exact<{ a: string }>'
+      'Invalid value 1 supplied to $Exact<{ a: string }>'
     ])
     assertValidationFailure(t.validate({}, T), [
-      'Invalid value undefined supplied to : $Exact<{ a: string }>/a: string'
+      'Invalid value undefined supplied to $Exact<{ a: string }>/a: string'
     ])
     assertValidationFailure(t.validate({ a: 1 }, T), [
-      'Invalid value 1 supplied to : $Exact<{ a: string }>/a: string'
+      'Invalid value 1 supplied to $Exact<{ a: string }>/a: string'
     ])
   })
 
   it('should check for additional props', () => {
     const T = t.$exact({ a: t.string })
     assertValidationFailure(t.validate({ a: 's', additional: 2 }, T), [
-      'Invalid value 2 supplied to : $Exact<{ a: string }>/additional: nil'
+      'Invalid value 2 supplied to $Exact<{ a: string }>/additional: nil'
     ])
   })
 

--- a/test/$keys.js
+++ b/test/$keys.js
@@ -23,14 +23,14 @@ describe('$keys', () => {
   it('should fail validating an invalid value (object type)', () => {
     const T = t.$keys(t.object({ a: t.string, b: t.number }))
     assertValidationFailure(t.validate('c', T), [
-      'Invalid value "c" supplied to : $Keys<{ a: string, b: number }>'
+      'Invalid value "c" supplied to $Keys<{ a: string, b: number }>'
     ])
   })
 
   it('should fail validating an invalid value (exact object type)', () => {
     const T = t.$keys(t.$exact({ a: t.string, b: t.number }))
     assertValidationFailure(t.validate('c', T), [
-      'Invalid value "c" supplied to : $Keys<$Exact<{ a: string, b: number }>>'
+      'Invalid value "c" supplied to $Keys<$Exact<{ a: string, b: number }>>'
     ])
   })
 

--- a/test/$shape.js
+++ b/test/$shape.js
@@ -34,17 +34,17 @@ describe('$shape', () => {
   it('should fail validating an invalid value', () => {
     const T = t.$shape(t.object({ a: t.string }))
     assertValidationFailure(t.validate(1, T), [
-      'Invalid value 1 supplied to : $Shape<{ a: string }>'
+      'Invalid value 1 supplied to $Shape<{ a: string }>'
     ])
     assertValidationFailure(t.validate({ a: 1 }, T), [
-      'Invalid value 1 supplied to : $Shape<{ a: string }>/a: string'
+      'Invalid value 1 supplied to $Shape<{ a: string }>/a: string'
     ])
   })
 
   it('should check for additional props', () => {
     const T = t.$shape(t.object({ a: t.string }))
     assertValidationFailure(t.validate({ a: 's', additional: 2 }, T), [
-      'Invalid value 2 supplied to : $Shape<{ a: string }>/additional: nil'
+      'Invalid value 2 supplied to $Shape<{ a: string }>/additional: nil'
     ])
   })
 

--- a/test/array.js
+++ b/test/array.js
@@ -34,10 +34,10 @@ describe('array', () => {
   it('should fail validating an invalid value', () => {
     const T = t.array(t.number)
     assertValidationFailure(t.validate(1, T), [
-      'Invalid value 1 supplied to : Array<number>'
+      'Invalid value 1 supplied to Array<number>'
     ])
     assertValidationFailure(t.validate([1, 's', 3], T), [
-      'Invalid value "s" supplied to : Array<number>/1: number'
+      'Invalid value "s" supplied to Array<number>/1: number'
     ])
   })
 

--- a/test/classOf.js
+++ b/test/classOf.js
@@ -29,7 +29,7 @@ describe('classOf', () => {
     class C {}
     const T = t.classOf(A)
     assertValidationFailure(t.validate(C, T), [
-      'Invalid value C supplied to : Class<A>'
+      'Invalid value C supplied to Class<A>'
     ])
   })
 

--- a/test/instanceOf.js
+++ b/test/instanceOf.js
@@ -26,7 +26,7 @@ describe('instanceOf', () => {
     class A {}
     const T = t.instanceOf(A)
     assertValidationFailure(t.validate(1, T), [
-      'Invalid value 1 supplied to : A'
+      'Invalid value 1 supplied to A'
     ])
   })
 

--- a/test/intersection.js
+++ b/test/intersection.js
@@ -34,7 +34,7 @@ describe('intersection', () => {
   it('should fail validating an invalid value', () => {
     const T = t.intersection([t.object({ a: t.number }), t.object({ b: t.number })])
     assertValidationFailure(t.validate({ a: 1 }, T), [
-      'Invalid value undefined supplied to : ({ a: number } & { b: number })/1: { b: number }/b: number'
+      'Invalid value undefined supplied to ({ a: number } & { b: number })/1/b: number'
     ])
   })
 

--- a/test/literal.js
+++ b/test/literal.js
@@ -16,7 +16,7 @@ describe('literal', () => {
   it('should fail validating an invalid value', () => {
     const T = t.literal({ value: 'a' })
     assertValidationFailure(t.validate(1, T), [
-      'Invalid value 1 supplied to : "a"'
+      'Invalid value 1 supplied to "a"'
     ])
   })
 

--- a/test/mapping.js
+++ b/test/mapping.js
@@ -34,10 +34,10 @@ describe('mapping', () => {
   it('should fail validating an invalid value', () => {
     const T = t.mapping(t.refinement(t.string, s => s.length >= 2), t.number)
     assertValidationFailure(t.validate({ a: 1 }, T), [
-      'Invalid value "a" supplied to : { [key: (string | <function1>)]: number }/a: (string | <function1>)'
+      'Invalid value "a" supplied to { [key: (string | <function1>)]: number }/a: (string | <function1>)'
     ])
     assertValidationFailure(t.validate({ aa: 's' }, T), [
-      'Invalid value "s" supplied to : { [key: (string | <function1>)]: number }/aa: number'
+      'Invalid value "s" supplied to { [key: (string | <function1>)]: number }/aa: number'
     ])
   })
 

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -25,7 +25,7 @@ describe('maybe', () => {
   it('should fail validating an invalid value', () => {
     const T = t.maybe(t.number)
     assertValidationFailure(t.validate('s', T), [
-      'Invalid value "s" supplied to : ?number'
+      'Invalid value "s" supplied to ?number'
     ])
   })
 

--- a/test/object.js
+++ b/test/object.js
@@ -38,13 +38,13 @@ describe('object', () => {
   it('should fail validating an invalid value', () => {
     const T = t.object({ a: t.string })
     assertValidationFailure(t.validate(1, T), [
-      'Invalid value 1 supplied to : { a: string }'
+      'Invalid value 1 supplied to { a: string }'
     ])
     assertValidationFailure(t.validate({}, T), [
-      'Invalid value undefined supplied to : { a: string }/a: string'
+      'Invalid value undefined supplied to { a: string }/a: string'
     ])
     assertValidationFailure(t.validate({ a: 1 }, T), [
-      'Invalid value 1 supplied to : { a: string }/a: string'
+      'Invalid value 1 supplied to { a: string }/a: string'
     ])
   })
 

--- a/test/recursion.js
+++ b/test/recursion.js
@@ -33,13 +33,13 @@ describe('recursion', () => {
       b: t.maybe(self)
     }))
     assertValidationFailure(t.validate(1, T), [
-      'Invalid value 1 supplied to : T'
+      'Invalid value 1 supplied to T'
     ])
     assertValidationFailure(t.validate({}, T), [
-      'Invalid value undefined supplied to : T/a: number'
+      'Invalid value undefined supplied to T/a: number'
     ])
     assertValidationFailure(t.validate({ a: 1, b: {} }, T), [
-      'Invalid value undefined supplied to : T/b: ?T/a: number'
+      'Invalid value undefined supplied to T/b/a: number'
     ])
   })
 

--- a/test/refinement.js
+++ b/test/refinement.js
@@ -24,7 +24,7 @@ describe('refinement', () => {
   it('should fail validating an invalid value', () => {
     const T = t.refinement(t.number, n => n >= 0)
     assertValidationFailure(t.validate(-1, T), [
-      'Invalid value -1 supplied to : (number | <function1>)'
+      'Invalid value -1 supplied to (number | <function1>)'
     ])
   })
 

--- a/test/tuple.js
+++ b/test/tuple.js
@@ -34,14 +34,14 @@ describe('tuple', () => {
   it('should fail validating an invalid value', () => {
     const T = t.tuple([t.number, t.string])
     assertValidationFailure(t.validate([], T), [
-      'Invalid value undefined supplied to : [number, string]/0: number',
-      'Invalid value undefined supplied to : [number, string]/1: string'
+      'Invalid value undefined supplied to [number, string]/0: number',
+      'Invalid value undefined supplied to [number, string]/1: string'
     ])
     assertValidationFailure(t.validate([1], T), [
-      'Invalid value undefined supplied to : [number, string]/1: string'
+      'Invalid value undefined supplied to [number, string]/1: string'
     ])
     assertValidationFailure(t.validate([1, 1], T), [
-      'Invalid value 1 supplied to : [number, string]/1: string'
+      'Invalid value 1 supplied to [number, string]/1: string'
     ])
   })
 

--- a/test/union.js
+++ b/test/union.js
@@ -24,7 +24,7 @@ describe('union', () => {
   it('should fail validating an invalid value', () => {
     const T = t.union([t.string, t.number])
     assertValidationFailure(t.validate(true, T), [
-      'Invalid value true supplied to : (string | number)'
+      'Invalid value true supplied to (string | number)'
     ])
   })
 


### PR DESCRIPTION
I find it hard to spot where the errors come from using complicated nested Object. This PR change the error description to display only the `key` in the path segments instead of the `key: name` entry.

Example: 

``` js
import * as t from 'flow-runtime';

t.validate(
  {
    a: {
      b: 'error',
    },
  },
  t.object({
    a: t.object({ b: t.boolean }),
  }, 'MyObject'),
);

// BEFORE:
// Invalid value "error" supplied to : MyObject/a: { b: boolean }/b: boolean

// AFTER:
// Invalid value "error" supplied to MyObject/a/b: boolean
```
